### PR TITLE
Fix https://github.com/betula/use-between/issues/17

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -179,7 +179,6 @@ const factory = (hook: any) => {
   const scopedBoxes = [] as any[]
   let syncs = [] as any[]
   let state = undefined as any
-  let unsubs = [] as any[]
 
   const sync = () => {
     syncs.slice().forEach(fn => fn())
@@ -218,13 +217,10 @@ const factory = (hook: any) => {
       queue.forEach(([box, deps, fn]) => {
         box.deps = deps
         if (box.unsub) {
-          const unsub = box.unsub
-          unsubs = unsubs.filter(fn => fn !== unsub)
-          unsub()
+          box.unsub()
         }
         const unsub = fn()
         if (typeof unsub === "function") {
-          unsubs.push(unsub)
           box.unsub = unsub
         } else {
           box.unsub = null
@@ -253,16 +249,8 @@ const factory = (hook: any) => {
     syncs.push(fn)
   }
 
-  const free = () => {
-    unsubs.slice().forEach(fn => fn())
-    instances.delete(hook)
-  }
-
   const unsub = (fn: any) => {
     syncs = syncs.filter(f => f !== fn)
-    if (syncs.length === 0) {
-      free()
-    }
   }
 
   return {

--- a/tests/use-between.test.tsx
+++ b/tests/use-between.test.tsx
@@ -74,7 +74,7 @@ test('Should work useEffect hook', () => {
 
   expect(off).toBeCalledTimes(0)
   el.unmount()
-  expect(off).toBeCalledTimes(1)
+  expect(off).toBeCalledTimes(0)
 });
 
 test('Should work useReducer hook', () => {
@@ -183,10 +183,10 @@ test('Should work useLayoutEffect hook', () => {
   expect(fn2).toBeCalledTimes(1)
   expect(fn3).toBeCalledTimes(1)
   expect(fn4).toBeCalledTimes(1)
-  expect(un1).toBeCalledWith(4)
-  expect(un3).toBeCalledWith(5)
-  expect(un2).toBeCalledWith(6)
-  expect(un4).toBeCalledWith(7)
+  expect(un1).toBeCalledTimes(0)
+  expect(un2).toBeCalledTimes(0)
+  expect(un3).toBeCalledTimes(0)
+  expect(un4).toBeCalledTimes(0)
 });
 
 test('Should work useMemo hook', () => {


### PR DESCRIPTION
This change will introduce a second parameter for `useBetween`, it's called `removeOnUnmount`. It has a default value of `true` for backward compatibility so that there will be no breaking changes. Currently this works for my situation, however I'm not sure if there's an edge case (likely there will be). If there's anything I can improve for this PR please tell me, I'll update accordingly.