### PR TITLE
React 19: add support for useEffectEvent hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,6 +119,16 @@ const ownDisptacher = {
 
     return box.fn
   },
+  
+  useEffectEvent(fn: any) {
+    const box = nextBox()
+    box.fn = fn
+    // "Effect Event functions do not have a stable identity. Their identity intentionally changes on every render."
+    // (https://react.dev/reference/react/useEffectEvent#reference)
+    box.event = (...args: any[]) => box.fn(...args)
+    box.initialized = true
+    return box.event
+  },
 
   useMemo(fn: any, deps: any[]) {
     const box = nextBox()

--- a/tests/use-between.test.tsx
+++ b/tests/use-between.test.tsx
@@ -7,7 +7,8 @@ import React, {
   useMemo,
   useRef,
   useImperativeHandle,
-  useContext
+  useContext,
+  useEffectEvent
 } from 'react'
 import { render, fireEvent } from '@testing-library/react'
 import { get, useBetween, free } from '../src'
@@ -176,6 +177,67 @@ test('Should work useCallback hook', () => {
   fireEvent.click(el.getByTestId('set-a'))
   expect(fns.length).toBe(3)
   expect(fns[2] === lastFn).toBeTruthy()
+});
+
+test('useEffectEvent hook should work', () => {
+  let listener: () => void = () => {}
+  let listenerInstances: Array<() => void> = []
+  let values: number[] = []
+  let effectCalls = 0
+
+  // Set up hook
+  const useHandler = () => {
+    const [value, setValue] = useState(10)
+
+    const handleChange = useEffectEvent(() => {
+      values.push(value)
+    })
+
+    listenerInstances.push(handleChange)
+
+    useEffect(() => {
+      listener = handleChange
+      effectCalls++
+    }, [])
+
+    return { setValue }
+  }
+
+  const A = () => {
+    const { setValue } = useBetween(useHandler)
+    return (
+      <>
+        <button data-testid="setter" onClick={() => setValue((x) => x + 10)} />
+      </>
+    )
+  }
+
+  // Render test component
+  const el = render(<A />)
+
+  // First render: calls useEffect
+  expect(effectCalls).toBe(1)
+  expect(values.length).toBe(0)
+  expect(listenerInstances.length).toBe(1)
+
+  // Call listener: new value, but no render
+  listener()
+  expect(effectCalls).toBe(1)
+  expect(values).toStrictEqual([10])
+  expect(listenerInstances.length).toBe(1)
+
+  // Second render: new listener instance, but no effect call
+  fireEvent.click(el.getByTestId("setter"))
+  expect(effectCalls).toBe(1)
+  expect(values).toStrictEqual([10])
+  expect(listenerInstances.length).toBe(2)
+  expect(listenerInstances[0]).not.toEqual(listenerInstances[1])
+
+  // Call listener: new value, but no render
+  listener()
+  expect(effectCalls).toBe(1)
+  expect(values).toStrictEqual([10, 20])
+  expect(listenerInstances.length).toBe(2)
 });
 
 test('Should work useLayoutEffect hook', () => {


### PR DESCRIPTION
This MR provides support for the new React 19 hook [useEffectEvent](https://react.dev/reference/react/useEffectEvent#usage).

This is a useful hook when you want to ignore "non-reactive" callbacks from effect dependencies.

After some npm dependency hacking, I got it to work locally and also added a unit test.

Note the particular design of `useEffectEvent`, which I have reproduced in this implementation:
> Effect Event functions do not have a stable identity. Their identity intentionally changes on every render.

Let me know what you think 😎 